### PR TITLE
Fix for outputing state, and pipeing into containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.1
 MAINTAINER Tim Hartmann <tim.hartmann@runkeeper.com>
 
-ENV ENVIRONMENT=production
+ENV ENVIRONMENT=docker
 RUN apt-get update
 RUN apt-get install cmake unzip libgit2-21 -y
 RUN mkdir -p /tmp/build && \

--- a/lib/leeroy/helpers/logging.rb
+++ b/lib/leeroy/helpers/logging.rb
@@ -21,7 +21,7 @@ module Leeroy
         Yell.new :syslog, name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :info, facility: :user
       elsif ENV['ENVIRONMENT'] == 'docker'
         # Do nothing
-        Yell.new :file, '/dev/null', name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :info, facility: :user
+        Yell.new :file, '/tmp/leeroy.log', name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :info, facility: :user
       else
         Yell.new :stderr, name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :debug
       end

--- a/lib/leeroy/helpers/logging.rb
+++ b/lib/leeroy/helpers/logging.rb
@@ -19,6 +19,9 @@ module Leeroy
       # Yell.new :stderr, name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :debug
       if ENV['ENVIRONMENT'] == 'production'
         Yell.new :syslog, name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :info, facility: :user
+      elsif ENV['ENVIRONMENT'] == 'docker'
+        # Do nothing
+        Yell.new :file, '/dev/null', name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :info, facility: :user
       else
         Yell.new :stderr, name: self.class.to_s, format: TRACE_FORMAT, trace: TRACE_LEVELS, level: :debug
       end


### PR DESCRIPTION
Thought I don't think you're going to like it...

`docker run --rm -it $IMAGE stub | docker run --rm -i $IMAGE stub`

now works, but we don't get any actual logging out of the running
container.. wah wah